### PR TITLE
Correct pre install specification

### DIFF
--- a/gem_pre_unversioned_install.gemspec
+++ b/gem_pre_unversioned_install.gemspec
@@ -9,7 +9,7 @@ $LOAD_PATH.merge! [File.expand_path('../lib', __FILE__)]
 Gem::Specification.new do |spec|
   raise 'RubyGems 2.0 or newer is required.' unless spec.respond_to?(:metadata)
   spec.name = 'gem_pre_unversioned_install'
-  spec.version = '1.0.0'
+  spec.version = '1.0.1'
   spec.authors = ['Andrew Smith']
   spec.email = ['andrew.smith at moneysupermarket.com']
 

--- a/lib/gem_pre_unversioned_install.rb
+++ b/lib/gem_pre_unversioned_install.rb
@@ -50,7 +50,7 @@ Gem.pre_install do |installer|
   # so we allow our plugins to do the same and trigger this behaviour
   rval = nil
   Gem._unversioned_hooks.each do |hook|
-    break unless (rval = hook.call(spec.name, spec.version))
+    break if false == (rval = hook.call(spec.name, spec.version))
   end
   rval
 end


### PR DESCRIPTION
pre_install implementation should _only_ fail if an explicit false is returned by the block.
This PR provides a minor fix in case blocks return nil.